### PR TITLE
Java-Squid-Game to print colorful text for GreenLight and RedLight, Type correction, added known issue section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Squid-Game
 Netflix's Squid Game in Java, but with less horror 😆. 
 
-# Explaination
+# Explanation
 Hey Tea lovers! Before talking about Squid Game in Java, let me ask you What do you do on a bored Sunday afternoon? Go out, have fun, or do Netflix and Chill right. Well, I did Netflix and chill. Well, not chill, but experienced a rollercoaster of emotions with the sensational Korean Drama Squid Game on Netflix. Oh Boy! What a massive hit it is. One of the best series I have seen. It has all the things and the story is gripping. Oh sorry, I am off to a different tangent. I know it’s not a movie review blog, but I can’t help but be amazed.
 
 Anyway, the thing I wanted to talk about is the games played in Squid Game. The games are very fun (Not like in the series but in real life). So I tried to replicate the same in Java. So I started with the Red Light Green Light.
 
-Read full explaination on... [How I Created Squid Game in Java: Red/Green Light](https://www.coderstea.com/post/java/how-i-created-squid-game-in-java-red-green-light/)
+Read full explanation on... [How I Created Squid Game in Java: Red/Green Light](https://www.coderstea.com/post/java/how-i-created-squid-game-in-java-red-green-light/)
 
 # GamePlay 
 
@@ -14,3 +14,20 @@ Read full explaination on... [How I Created Squid Game in Java: Red/Green Light]
 ![GamePlay 1](https://media.giphy.com/media/SopXUq7XkQgH4ngegZ/giphy.gif)
 
 **Class** : `com.coderstea.squidgame.RedLightGreenLight`
+
+## Known Issues & Temporary solution
+
+-----------------------------------
+
+#### 1. Windows Command Prompt (cmd.exe) will not show Emoji's
+        It seems Windows command prompt (cmd) will not load Emoji's.
+#### 2. Windows Powershell (powershell.exe) will not show Emoji's
+        It seems Windows powershell (powershell.exe) will not load Emoji's.
+#### 3. Windows Terminal (wt.exe) to Display Emoji
+        1. Open Windows 10 Terminal app (wt.exe).
+        2. Type `chcp 65001` and press enter. (without quotes)
+        3. Run the java application.
+        Note:   Running the App directly will not show Emoji. 
+                Rerun the app again in same window must show emoji.
+
+![wt.exe_Preview](https://media0.giphy.com/media/8IdEb6FSox4siJrUuW/giphy.gif?cid=790b7611dcd7587d322d3abfdbb481e50c670b9c4dbb26a5&rid=giphy.gif&ct=g)

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,50 @@
     <groupId>com.coderstea</groupId>
     <artifactId>Squid-Game</artifactId>
     <version>0.1</version>
+    <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>
+                                        com.coderstea.squidgame.SquidGameJava
+                                    </mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <!-- put the default-jar in the none phase to skip it from being created -->
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/coderstea/squidgame/SquidGameJava.java
+++ b/src/main/java/com/coderstea/squidgame/SquidGameJava.java
@@ -1,31 +1,32 @@
 package com.coderstea.squidgame;
 
 import com.coderstea.squidgame.games.RedLightGreenLight;
+import com.coderstea.squidgame.util.Util;
 
 import java.util.Scanner;
 
 import static java.lang.System.exit;
 
 public class SquidGameJava {
+
   public static void main(String[] args) {
     Scanner sc = new Scanner(System.in);
     int gameNo = 0;
     try {
       do {
-        // This will allow the cmd to use the ANSI colors and emoji.
+        // This will allow the cmd to use the ANSI colors and emoji for Windows OS only
         // check README.md for the known issues.
-        ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", "chcp", "65001").inheritIO();
-        Process p = pb.start();
-        p.waitFor();
-
-        if(!p.isAlive()) {
+          if(Util.isWindows()) {
+            ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", "chcp", "65001").inheritIO();
+            Process cmdProcess = pb.start();
+            cmdProcess.waitFor();
+          }
           System.out.println("Starting Squid Game. Please select a Game to play");
           System.out.println("1. Red Light Green Light");
           System.out.println("5. Don't Want to Play");
           System.out.println("Your Choice: ");
           gameNo = sc.nextInt();
           startGame(gameNo);
-        }
       } while (gameNo > 5);
     } catch (Exception e){
       e.printStackTrace();

--- a/src/main/java/com/coderstea/squidgame/SquidGameJava.java
+++ b/src/main/java/com/coderstea/squidgame/SquidGameJava.java
@@ -4,18 +4,28 @@ import com.coderstea.squidgame.games.RedLightGreenLight;
 
 import java.util.Scanner;
 
+import static java.lang.System.exit;
+
 public class SquidGameJava {
   public static void main(String[] args) {
     Scanner sc = new Scanner(System.in);
     int gameNo = 0;
     try {
       do {
-        System.out.println("Starting Squid Game. Please select a Game to play");
-        System.out.println("1. Red Light Green Light");
-        System.out.println("5. Don't Want to Play");
-        System.out.println("Your Choice: ");
-        gameNo = sc.nextInt();
-        startGame(gameNo);
+        // This will allow the cmd to use the ANSI colors and emoji.
+        // check README.md for the known issues.
+        ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", "chcp", "65001").inheritIO();
+        Process p = pb.start();
+        p.waitFor();
+
+        if(!p.isAlive()) {
+          System.out.println("Starting Squid Game. Please select a Game to play");
+          System.out.println("1. Red Light Green Light");
+          System.out.println("5. Don't Want to Play");
+          System.out.println("Your Choice: ");
+          gameNo = sc.nextInt();
+          startGame(gameNo);
+        }
       } while (gameNo > 5);
     } catch (Exception e){
       e.printStackTrace();

--- a/src/main/java/com/coderstea/squidgame/games/RedLightGreenLight.java
+++ b/src/main/java/com/coderstea/squidgame/games/RedLightGreenLight.java
@@ -7,10 +7,17 @@ import static com.coderstea.squidgame.util.Util.sleep;
 
 public class RedLightGreenLight implements SquidGame {
 
+  //Use Windows ANSI color code
+  public static final String ANSI_RESET = "\u001B[0m";
+  public static final String ANSI_RED = "\u001B[31m";
+  public static final String ANSI_GREEN = "\u001B[32m";
+  public static final String ANSI_CYAN = "\u001B[36m";
+
   // Windows User may not be able to see actual Red Emoji
-  private static final String RED_LIGHT = "Red Light 🔴 👧";
-  private static final String GREEN_LIGHT = "Green Light 🟢 👧";
-  private static final String GAME_OVER = "Game Over 🤯🔫 (press Enter)";
+  private static final String RED_LIGHT = ANSI_RED + "Red Light 🔴 👧" + ANSI_RESET;
+  private static final String GREEN_LIGHT = ANSI_GREEN + "Green Light 🟢 👧"+ ANSI_RESET;
+  private static final String GAME_OVER = ANSI_CYAN + "💔 Game Over 🤯🔫  😵 (press Enter)"+ ANSI_RESET;
+
 
   private static final int TIME_LIMIT = 1000 * 60; //  1 Minute
   private static final int BREATHER = 500;
@@ -25,7 +32,7 @@ public class RedLightGreenLight implements SquidGame {
   @Override
   public void startGame() throws InterruptedException {
     scanner = new Scanner(System.in);
-    boolean continuePlaying = false;
+    boolean continuePlaying;
     do {
       // resetting varibales
       pressCount = 0;

--- a/src/main/java/com/coderstea/squidgame/util/Util.java
+++ b/src/main/java/com/coderstea/squidgame/util/Util.java
@@ -1,11 +1,17 @@
 package com.coderstea.squidgame.util;
 
 public class Util {
+  private static String OS = System.getProperty("os.name").toLowerCase();
+
   public static void sleep(int time) {
     try {
       Thread.sleep(time);
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
+  }
+
+  public static boolean isWindows() {
+    return (OS.indexOf("win") >= 0);
   }
 }


### PR DESCRIPTION
Java-Squid-Game
1. Windows terminal, command prompt, gitbash or powershell to show Color for the Text "RedLight" & "GreenLight"
2. Allowed java program to change the console to chcp 65001 (UTF-8 char mode).
3. Fixed type in README.md, added Known Issue section, also added win terminal output gif.
4. pom.xml to have jar packaging build option. so that the game can be played from any PC without the source code.


Let me know if there are any questions with the changes.